### PR TITLE
Simplifies compiler path in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,5 @@
         },
     ],
     "cortex-debug.variableUseNaturalFormat": true,
-    "C_Cpp.default.compilerPath": "E:/Arm_Toolchain/arm-none-eabi/14.2rel1/bin/arm-none-eabi-gcc.exe"
+    "C_Cpp.default.compilerPath": "arm-none-eabi-gcc.exe"
 }


### PR DESCRIPTION
Updates the compiler path setting in `.vscode/settings.json` to use
a relative executable name instead of an absolute path. This change
improves portability and ensures the configuration works across
different environments without requiring path adjustments.